### PR TITLE
deprecated use of cufftSetCompatibilityMode(...,CUFFT_COMPATIBILITY_N…

### DIFF
--- a/src/convolution3Dfft.cu
+++ b/src/convolution3Dfft.cu
@@ -211,6 +211,8 @@ void writeOutCUDAfft(char* filename,imageType* fftCUDA,int* fftCUDAdims)
 
 //=====================================================================
 //WARNING: for cuFFT the fastest running index is z direction!!! so pos = z + imDim[2] * (y + imDim[1] * x)
+
+//WARNING: the following function assumes the old cufft native format for the array and has not yet been ported to fftw style layout
 imageType* convolution3DfftCUDA_test(imageType* im,
 				     int* imDim,
 				     imageType* kernel,
@@ -253,9 +255,11 @@ imageType* convolution3DfftCUDA_test(imageType* im,
 	
 	//printf("Creating R2C & C2R FFT plans for size %i x %i x %i\n",imDim[0],imDim[1],imDim[2]);
 	CUFFT_ERROR(cufftPlan3d(&fftPlanFwd, imDim[0], imDim[1], imDim[2], CUFFT_R2C));
-	CUFFT_ERROR(cufftSetCompatibilityMode(fftPlanFwd,CUFFT_COMPATIBILITY_NATIVE)); //for highest performance since we do not need FFTW compatibility
 	CUFFT_ERROR(cufftPlan3d(&fftPlanInv, imDim[0], imDim[1], imDim[2], CUFFT_C2R));
+#if CUDART_VERSION <= 7500
+	CUFFT_ERROR(cufftSetCompatibilityMode(fftPlanFwd,CUFFT_COMPATIBILITY_NATIVE)); //for highest performance since we do not need FFTW compatibility
 	CUFFT_ERROR(cufftSetCompatibilityMode(fftPlanInv,CUFFT_COMPATIBILITY_NATIVE));
+#endif
 
 	//transforming convolution kernel; TODO: if I do multiple convolutions with the same kernel I could reuse the results at teh expense of using out-of place memory (and then teh layout of the data is different!!!! so imCUDAfft should also be out of place)
 	//NOTE: from CUFFT manual: If idata and odata are the same, this method does an in-place transform.
@@ -288,7 +292,9 @@ imageType* convolution3DfftCUDA_test(imageType* im,
 
 //=====================================================================
 //WARNING: for cuFFT the fastest running index is z direction!!! so pos = z + imDim[2] * (y + imDim[1] * x)
-//NOTE: to avoid transferring a large padded kernel, since memcpy is a limiting factor 
+//NOTE: to avoid transferring a large padded kernel, since memcpy is a limiting factor
+
+//WARNING: the following function assumes the old cufft native format for the array and has not yet been ported to fftw style layout
  imageType* convolution3DfftCUDA(imageType* im,
 				 int* imDim,
 				 imageType* kernel,
@@ -346,10 +352,13 @@ imageType* convolution3DfftCUDA_test(imageType* im,
 
 	//printf("Creating R2C & C2R FFT plans for size %i x %i x %i\n",imDim[0],imDim[1],imDim[2]);
 	CUFFT_ERROR(cufftPlan3d(&fftPlanFwd, imDim[0], imDim[1], imDim[2], CUFFT_R2C));
-	CUFFT_ERROR(cufftSetCompatibilityMode(fftPlanFwd,CUFFT_COMPATIBILITY_NATIVE)); //for highest performance since we do not need FFTW compatibility
 	CUFFT_ERROR(cufftPlan3d(&fftPlanInv, imDim[0], imDim[1], imDim[2], CUFFT_C2R));
-	CUFFT_ERROR(cufftSetCompatibilityMode(fftPlanInv,CUFFT_COMPATIBILITY_NATIVE));
 
+#if CUDART_VERSION <= 7500
+	CUFFT_ERROR(cufftSetCompatibilityMode(fftPlanFwd,CUFFT_COMPATIBILITY_NATIVE)); //for highest performance since we do not need FFTW compatibility
+	CUFFT_ERROR(cufftSetCompatibilityMode(fftPlanInv,CUFFT_COMPATIBILITY_NATIVE));
+#endif
+	
 	//transforming convolution kernel; TODO: if I do multiple convolutions with the same kernel I could reuse the results at teh expense of using out-of place memory (and then teh layout of the data is different!!!! so imCUDAfft should also be out of place)
 	//NOTE: from CUFFT manual: If idata and odata are the same, this method does an in-place transform.
 	//NOTE: from CUFFT manual: inplace output data xy(z/2 + 1) with fcomplex. Therefore, in order to perform an in-place FFT, the user has to pad the input array in the last dimension to Nn2 + 1 complex elements interleaved. Note that the real-to-complex transform is implicitly forward.
@@ -534,7 +543,6 @@ imageType* convolution3DfftCUDA_test(imageType* im,
 	THROW_CUFFT_ERROR(cufftPlan3d(&fftPlanInv, stack_shape[fc::row_major::z], stack_shape[fc::row_major::y], stack_shape[fc::row_major::x], CUFFT_C2R));
 
 	//TODO: check if this is needed with CUDA 6.*
-	// cufftSetCompatibilityMode(fftPlanInv,CUFFT_COMPATIBILITY_NATIVE);HANDLE_ERROR_KERNEL;
 	THROW_CUFFT_ERROR(cufftExecC2R(fftPlanInv, imCUDA, (cufftReal *)imCUDA));
 	
 


### PR DESCRIPTION
…ATIVE) for all cuda sdk versions > 7.5
