### PR TITLE
Fix compilation errors in tests/test_how_cufft_works.cu

### DIFF
--- a/tests/test_how_cufft_works.cu
+++ b/tests/test_how_cufft_works.cu
@@ -1,11 +1,11 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE TEST_HOW_CUFFT_WORKS
 
-#ifdef __CUDACC_VER_MAJOR__
-#if __CUDACC_VER_MAJOR__ >= 9
-#define __CUDACC_VER__ 90000
-#endif
-#endif
+//#ifdef __CUDACC_VER_MAJOR__
+//#if __CUDACC_VER_MAJOR__ >= 9
+//#define __CUDACC_VER__ 90000
+//#endif
+//#endif
 
 #include "boost/test/unit_test.hpp"
 #include <numeric>
@@ -81,8 +81,6 @@ namespace fourierconvolution {
     //FORWARD
     cufftHandle fftPlanFwd;
     CUFFT_ERROR(cufftPlan3d(&fftPlanFwd, shape[row_major::z], shape[row_major::y], shape[row_major::x], CUFFT_R2C));
-    if(CUDART_VERSION < 6050)
-      CUFFT_ERROR(cufftSetCompatibilityMode(fftPlanFwd,CUFFT_COMPATIBILITY_FFTW_PADDING));
 
     CUFFT_ERROR(cufftExecR2C(fftPlanFwd, (cufftReal*)d_stack, (cufftComplex *)d_stack));
     CUFFT_ERROR(cufftDestroy(fftPlanFwd));
@@ -96,8 +94,6 @@ namespace fourierconvolution {
     //BACKWARD
     cufftHandle fftPlanInv;
     CUFFT_ERROR(cufftPlan3d(&fftPlanInv, shape[row_major::z], shape[row_major::y], shape[row_major::x], CUFFT_C2R));
-    if(CUDART_VERSION < 6050)
-      CUFFT_ERROR(cufftSetCompatibilityMode(fftPlanInv,CUFFT_COMPATIBILITY_FFTW_PADDING));
 
     CUFFT_ERROR(cufftExecC2R(fftPlanInv, (cufftComplex*)d_stack, (cufftReal *)d_stack));
     CUFFT_ERROR(cufftDestroy(fftPlanInv) );
@@ -151,8 +147,6 @@ namespace fourierconvolution {
     //FORWARD
     cufftHandle fftPlanFwd;
     CUFFT_ERROR(cufftPlan3d(&fftPlanFwd, shape[row_major::z], shape[row_major::y], shape[row_major::x], CUFFT_R2C));
-    if(CUDART_VERSION < 6050)
-      CUFFT_ERROR(cufftSetCompatibilityMode(fftPlanFwd,CUFFT_COMPATIBILITY_FFTW_PADDING));
     CUFFT_ERROR(cufftExecR2C(fftPlanFwd, d_real, d_complex));
 
     //apply scale
@@ -164,8 +158,6 @@ namespace fourierconvolution {
     //BACKWARD
     cufftHandle fftPlanInv;
     CUFFT_ERROR(cufftPlan3d(&fftPlanInv, shape[row_major::z], shape[row_major::y], shape[row_major::x], CUFFT_C2R));
-    if(CUDART_VERSION < 6050)
-      CUFFT_ERROR(cufftSetCompatibilityMode(fftPlanInv,CUFFT_COMPATIBILITY_FFTW_PADDING));
 
     CUFFT_ERROR(cufftExecC2R(fftPlanInv, d_complex, d_real));
 


### PR DESCRIPTION
... in Ubuntu 16.04 with CUDA 10.0.

All this commit does is remove code that sets a compatibility mode for CUDA versions earlier than 6050.

All tests pass with ctests.